### PR TITLE
chore: Update Hugo to v0.147.7, Hextra to v0.9.7, Go to v1.24.4, and bump workflow action dep versions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "features": {
     "ghcr.io/devcontainers/features/hugo:1": {
       "extended": true,
-      "version": "0.132.2"
+      "version": "0.147.7"
     },
     "ghcr.io/devcontainers/features/node:1": {}
   },

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.145.0
+      HUGO_VERSION: 0.147.7
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,10 +41,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24.4'
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Setup Hugo
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/imfing/hextra-starter-template
 
 go 1.21
 
-require github.com/imfing/hextra v0.9.5 // indirect
+require github.com/imfing/hextra v0.9.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/imfing/hextra-starter-template
 
-go 1.21
+go 1.24.4
 
 require github.com/imfing/hextra v0.9.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/imfing/hextra v0.9.5 h1:lG6wnklT9PNLepq69Gj3GZyHRUkBWwv6bkPVL9yAcIQ=
-github.com/imfing/hextra v0.9.5/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.9.7 h1:Zg5n24us36Bn/S/5mEUPkRW6uwE6vHHEqWSgN0bPXaM=
+github.com/imfing/hextra v0.9.7/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@ publish = "public"
 command = "hugo --gc --minify -b ${DEPLOY_PRIME_URL}"
 
 [build.environment]
-HUGO_VERSION = "0.138.0"
+HUGO_VERSION = "0.147.7"


### PR DESCRIPTION
- [x] 13b7abaa92c2d9ce0c9fbb621f32d20b43551d83: `devcontainer.json` - update Hugo version from 0.132.2 to 0.147.7 
- [x] a441ca21e19f753e9653d938b524b260a72447ae: `pages.yaml` - update Hugo version to 0.147.7, Go version to 1.24.4, actions/configure-pages version to 5
- [x] 3373df13e56eb82998c748485b511cc0e6b1cb5f: `go.mod` - bump github.com/imfing/hextra from v0.9.5 to v0.9.7
- [x] 1cae750d3887b86026781f1daf516de80aacd292: `go.sum` - bump github.com/imfing/hextra:h1/go.mod from v0.9.5 to v0.9.7
- [x] d51d7f7c14209a8c3364c94a4dac6b6efef69d63: `‎netlify.toml` - bump netlify build env Hugo version from 0.138.0 to 0.147.7
- [x] c823ae17553b7dc3bd23184022c4cda5e6236ed3: `go.mod` - fix missed go version update from 1.21 to 1.24.4